### PR TITLE
add a script to run all tests of interest on ARM

### DIFF
--- a/microarchitecturometer_generator.py
+++ b/microarchitecturometer_generator.py
@@ -95,6 +95,15 @@ except ValueError:
     print("Invalid number of parameters.", file=sys.stderr)
     raise SystemExit
 
+
+if work_arg == '--list-padding':
+    for key in padding_opts:
+        if padding_arg in key:
+            print(key, end=" ")
+    print()
+    sys.exit(0)
+
+
 try:
     work_choice = work_opts[work_arg]
 except KeyError:

--- a/run-arm.sh
+++ b/run-arm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Using CC=${CC:=gcc}"
+echo "Using RESULTS_DIR=${RESULTS_DIR:=results}"
+echo "Using PADDING_LIST=${PADDING_LIST:=nop mov cmp \
+$(python3 microarchitecturometer_generator.py --list-padding aarch64)}"
+
+mkdir -p "$RESULTS_DIR"
+
+for padding in $PADDING_LIST; do
+    start=$(date +%s%3N)
+    base="microarchitecturometer-$padding"
+    echo -ne "Building and running $base.c:\t"
+    python3 microarchitecturometer_generator.py mem $padding > "$base.c"
+    $CC "$base.c" -O3 -o "$base.out"
+    "./$base.out" > "$RESULTS_DIR/$padding.txt"
+    echo "DONE in $(($(date +%s%3N) - start)) ms"
+done


### PR DESCRIPTION
Enables one-shot collection of results, by running ./run-arm.sh.

Some parameters are configurable by environment variable,
such as the compiler (CC), result directory (RESULT_DIR), etc,
although reasonable defaults are chosen if you don't specify them.

The list of tests is obtained by querying the generator for tests
with aarch64 in their name, plus a hardcoded list of tests that
are polygot between x86 and Arm (nop, mov, etc).